### PR TITLE
feat : 정해진 시간동안 전투 진행하다가 시간이 다 되면 하던 행동 멈추기

### DIFF
--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+public class BattleStageDataTable
+{
+	public event Action<float> OnUpdateBattleRemainTime;
+
+	private float _gameBattleTime = 0f;
+	public float updateTime
+	{
+		set
+		{
+			_gameBattleTime -= value;
+
+			_gameBattleTime = MathF.Max(0f, _gameBattleTime);
+			OnUpdateBattleRemainTime?.Invoke(_gameBattleTime);
+		}
+	}
+
+	public void Initialize(float gameBattleTime)
+	{
+		_gameBattleTime = gameBattleTime;
+	}
+
+	public void Reset()
+	{
+		OnUpdateBattleRemainTime = null;
+	}
+}

--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs.meta
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8c491ffd6d778746b973265bccf6f5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
@@ -17,6 +17,8 @@ public class BattleStageManager : MonoBehaviour
 			_dataTableManager = gameManager.dataTableManager;
 			_championManager = gameManager.championManager;
 			_pilotManager = gameManager.pilotManager;
+
+			_battleStageDataTable = _dataTableManager.battleStageDataTable;
 		}
 	}
 
@@ -24,6 +26,7 @@ public class BattleStageManager : MonoBehaviour
 	private ChampionManager _championManager;
 	private PilotManager _pilotManager;
 	private DataTableManager _dataTableManager;
+	private BattleStageDataTable _battleStageDataTable;
 
 	public BattleTeam redTeam { get; private set; }
 	public BattleTeam blueTeam { get; private set; }
@@ -38,10 +41,25 @@ public class BattleStageManager : MonoBehaviour
 		new Vector2(-5f, -2.5f), new Vector2(-3f, 1.5f)
 	};
 
+	private void Awake()
+	{
+		
+	}
+
 	private void Start()
 	{
 		SetupBattleTeam();
 		SetupPilot();
+
+		_battleStageDataTable.OnUpdateBattleRemainTime -= OnUpdateBattleRemainTime;
+		_battleStageDataTable.OnUpdateBattleRemainTime += OnUpdateBattleRemainTime;
+
+		_battleStageDataTable.Initialize(10f);
+	}
+
+	private void Update()
+	{
+		_battleStageDataTable.updateTime = Time.deltaTime;
 	}
 
 	private void SetupBattleTeam()
@@ -85,5 +103,36 @@ public class BattleStageManager : MonoBehaviour
 
 		redTeam.TestColorChange(Color.red);
 		blueTeam.TestColorChange(Color.blue);
+	}
+
+	UnityEngine.UI.Text _remainTimeText;
+
+	private void OnUpdateBattleRemainTime(float remainTime)
+	{
+		if(null == _remainTimeText)
+		{
+			_remainTimeText = GameObject.Find("remainingTimeText").GetComponent<UnityEngine.UI.Text>();
+		}
+
+		// 소수점 자리 올린 뒤 텍스트 표현..
+		_remainTimeText.text = ((int)(remainTime + 0.99f)).ToString();
+
+		if (remainTime <= 0f)
+		{
+			OnBattleEnd();
+
+			_battleStageDataTable.Reset();
+		}
+	}
+
+	// 배틀 종료 시 호출될 함수..
+	private void OnBattleEnd()
+	{
+		Debug.Log("배틀이 종료되었다.");
+
+		StopAllCoroutines();
+
+		redTeam.OnBattleEnd();
+		blueTeam.OnBattleEnd();
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/DataTableManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/DataTableManager.cs
@@ -9,6 +9,7 @@ public class DataTableManager : MonoBehaviour
 	public PilotDataTable pilotDataTable { get; private set; }
 	public EffectDataTable effectDataTable { get; private set; }
 	public AttackActionDataTable attackActionDataTable { get; private set; }
+	public BattleStageDataTable battleStageDataTable { get; private set; }
 
 	private void Awake()
 	{
@@ -16,6 +17,7 @@ public class DataTableManager : MonoBehaviour
 		pilotDataTable = new PilotDataTable();
 		effectDataTable = new EffectDataTable();
 		attackActionDataTable = new AttackActionDataTable();
+		battleStageDataTable = new BattleStageDataTable();
 
 		Champion.s_dataTableManager = this;
 	}

--- a/2DProject-TeamfightManager/Assets/Scripts/Pilot/PilotBattle.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Pilot/PilotBattle.cs
@@ -27,4 +27,11 @@ public class PilotBattle : MonoBehaviour
     {
         myTeam.OnChampionDead(champion);
     }
+
+    public void StopChampionLogic()
+    {
+        _controlChampion.GetComponent<ChampionController>().enabled = false;
+        _controlChampion.GetComponentInChildren<ChampionAnimation>().ChangeState(ChampionAnimation.AnimState.Idle);
+		_controlChampion.enabled = false;
+	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
@@ -95,6 +95,17 @@ public class BattleTeam : MonoBehaviour
 		_activeChampions.Add(champion);
 	}
 
+	public void OnBattleEnd()
+	{
+		StopAllCoroutines();
+
+		int loopCount = _pilots.Count;
+		for (int i = 0; i < loopCount; ++i)
+		{
+			_pilots[i].StopChampionLogic();
+		}
+	}
+
 	public void TestColorChange(Color color)
 	{
 		foreach (var pilot in enemyTeam._pilots)


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 정해진 시간동안 전투를 진행하다가 시간이 다 되면 하던 행동을 다 종료한다

# 제안 사항
 - 전투 데이터를 저장할 데이터 테이블 생성 및 정보 저장
 > 전투 시 필요한 데이터들을 저장하기 위한 데이터 테이블을 만들었고, 거기에 데이터를 저장해 필요한 곳에서 사용할 수 있도록 구현했다.

 - 배틀 스테이지 매니저 스크립트에서 전투 시간 설정 및 시간에 따라 데이터 테이블의 남은 전투 시간을 갱신해줬다.
 > 데이터 테이블에서 정보를 가지고 있고 필요하다면 가져갈 수 있게 해야하기 때문에 전투 시간 설정 및 남은 전투 시간 갱신은 배틀 스테이지 매니저에서 담당하고 데이터 테이블에서는 갱신된 데이터가 있다면 event 를 실행해 필요한 객체가 있다면 알아서 가져가도록 시스템을 구현했다.

# 스크린샷
- 배틀 스테이지 데이터 테이블(이건 기본 구성이고 여기에 필요한 데이터들을 계속해서 추가해주는 식으로 완성시켜 나갈 예정이다)
![image](https://user-images.githubusercontent.com/120010342/230575113-1d39ab48-6835-41ad-bbfe-ea93913415a7.png)

- 배틀 스테이지에서 남은 시간에 따라 로직 처리하는 부분
![image](https://user-images.githubusercontent.com/120010342/230575487-b217a79b-69b9-4cb0-a3b8-bd74946c8a66.png)

- 결과(10초로 설정하고 테스트해봤다, 10초가 지나면 정상적으로 모든 챔피언들이 하던 행동을 멈춘다)
![정해진 시간 동안 전투 적용 후 결과](https://user-images.githubusercontent.com/120010342/230575782-59b5bd3e-ab88-442d-bdf5-9bbaf4ecac32.gif)
