### PR TITLE
Feat #13 배틀 스테이지 시스템 구현

### DIFF
--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+public class BattleStageDataTable
+{
+	public event Action<float> OnUpdateBattleRemainTime;
+
+	private float _gameBattleTime = 0f;
+	public float updateTime
+	{
+		set
+		{
+			_gameBattleTime -= value;
+
+			_gameBattleTime = MathF.Max(0f, _gameBattleTime);
+			OnUpdateBattleRemainTime?.Invoke(_gameBattleTime);
+		}
+	}
+
+	public void Initialize(float gameBattleTime)
+	{
+		_gameBattleTime = gameBattleTime;
+	}
+
+	public void Reset()
+	{
+		OnUpdateBattleRemainTime = null;
+	}
+}

--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
@@ -4,23 +4,27 @@ public class BattleStageDataTable
 {
 	public event Action<float> OnUpdateBattleRemainTime;
 
-	private float _gameBattleTime = 0f;
+	private float _battleRemainTime = 0f;	// 배틀 총 남은 시간..
+
+	// 배틀 시간 갱신..
 	public float updateTime
 	{
 		set
 		{
-			_gameBattleTime -= value;
+			_battleRemainTime -= value;
 
-			_gameBattleTime = MathF.Max(0f, _gameBattleTime);
-			OnUpdateBattleRemainTime?.Invoke(_gameBattleTime);
+			_battleRemainTime = MathF.Max(0f, _battleRemainTime);
+			OnUpdateBattleRemainTime?.Invoke(_battleRemainTime);
 		}
 	}
 
+	// 배틀 시작 시 총 배틀해야하는 시간 받아서 초기화하는 부분..
 	public void Initialize(float gameBattleTime)
 	{
-		_gameBattleTime = gameBattleTime;
+		_battleRemainTime = gameBattleTime;
 	}
 
+	// 배틀 끝났을 때 관련 데이터 처리하는 부분..
 	public void Reset()
 	{
 		OnUpdateBattleRemainTime = null;

--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs.meta
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8c491ffd6d778746b973265bccf6f5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
@@ -105,14 +105,11 @@ public class BattleStageManager : MonoBehaviour
 		blueTeam.TestColorChange(Color.blue);
 	}
 
-	UnityEngine.UI.Text _remainTimeText;
-
+	// 배틀 남은 시간 갱신되면 호출되는 콜백 함수..
 	private void OnUpdateBattleRemainTime(float remainTime)
 	{
-		if(null == _remainTimeText)
-		{
-			_remainTimeText = GameObject.Find("remainingTimeText").GetComponent<UnityEngine.UI.Text>();
-		}
+		// 이 부분은 테스트용 코드다(UI 작업 시 UI 스크립트에서 처리하도록 바꿔야 한다)
+		UnityEngine.UI.Text _remainTimeText = GameObject.Find("remainingTimeText").GetComponent<UnityEngine.UI.Text>();
 
 		// 소수점 자리 올린 뒤 텍스트 표현..
 		_remainTimeText.text = ((int)(remainTime + 0.99f)).ToString();
@@ -128,7 +125,9 @@ public class BattleStageManager : MonoBehaviour
 	// 배틀 종료 시 호출될 함수..
 	private void OnBattleEnd()
 	{
+#if UNITY_EDITOR
 		Debug.Log("배틀이 종료되었다.");
+#endif
 
 		StopAllCoroutines();
 

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
@@ -17,6 +17,8 @@ public class BattleStageManager : MonoBehaviour
 			_dataTableManager = gameManager.dataTableManager;
 			_championManager = gameManager.championManager;
 			_pilotManager = gameManager.pilotManager;
+
+			_battleStageDataTable = _dataTableManager.battleStageDataTable;
 		}
 	}
 
@@ -24,6 +26,7 @@ public class BattleStageManager : MonoBehaviour
 	private ChampionManager _championManager;
 	private PilotManager _pilotManager;
 	private DataTableManager _dataTableManager;
+	private BattleStageDataTable _battleStageDataTable;
 
 	public BattleTeam redTeam { get; private set; }
 	public BattleTeam blueTeam { get; private set; }
@@ -38,10 +41,25 @@ public class BattleStageManager : MonoBehaviour
 		new Vector2(-5f, -2.5f), new Vector2(-3f, 1.5f)
 	};
 
+	private void Awake()
+	{
+		
+	}
+
 	private void Start()
 	{
 		SetupBattleTeam();
 		SetupPilot();
+
+		_battleStageDataTable.OnUpdateBattleRemainTime -= OnUpdateBattleRemainTime;
+		_battleStageDataTable.OnUpdateBattleRemainTime += OnUpdateBattleRemainTime;
+
+		_battleStageDataTable.Initialize(10f);
+	}
+
+	private void Update()
+	{
+		_battleStageDataTable.updateTime = Time.deltaTime;
 	}
 
 	private void SetupBattleTeam()
@@ -85,5 +103,36 @@ public class BattleStageManager : MonoBehaviour
 
 		redTeam.TestColorChange(Color.red);
 		blueTeam.TestColorChange(Color.blue);
+	}
+
+	UnityEngine.UI.Text _remainTimeText;
+
+	private void OnUpdateBattleRemainTime(float remainTime)
+	{
+		if(null == _remainTimeText)
+		{
+			_remainTimeText = GameObject.Find("remainingTimeText").GetComponent<UnityEngine.UI.Text>();
+		}
+
+		// 소수점 자리 올린 뒤 텍스트 표현..
+		_remainTimeText.text = ((int)(remainTime + 0.99f)).ToString();
+
+		if (remainTime <= 0f)
+		{
+			OnBattleEnd();
+
+			_battleStageDataTable.Reset();
+		}
+	}
+
+	// 배틀 종료 시 호출될 함수..
+	private void OnBattleEnd()
+	{
+		Debug.Log("배틀이 종료되었다.");
+
+		StopAllCoroutines();
+
+		redTeam.OnBattleEnd();
+		blueTeam.OnBattleEnd();
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/DataTableManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/DataTableManager.cs
@@ -9,6 +9,7 @@ public class DataTableManager : MonoBehaviour
 	public PilotDataTable pilotDataTable { get; private set; }
 	public EffectDataTable effectDataTable { get; private set; }
 	public AttackActionDataTable attackActionDataTable { get; private set; }
+	public BattleStageDataTable battleStageDataTable { get; private set; }
 
 	private void Awake()
 	{
@@ -16,6 +17,7 @@ public class DataTableManager : MonoBehaviour
 		pilotDataTable = new PilotDataTable();
 		effectDataTable = new EffectDataTable();
 		attackActionDataTable = new AttackActionDataTable();
+		battleStageDataTable = new BattleStageDataTable();
 
 		Champion.s_dataTableManager = this;
 	}

--- a/2DProject-TeamfightManager/Assets/Scripts/Pilot/PilotBattle.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Pilot/PilotBattle.cs
@@ -27,4 +27,11 @@ public class PilotBattle : MonoBehaviour
     {
         myTeam.OnChampionDead(champion);
     }
+
+    public void StopChampionLogic()
+    {
+        _controlChampion.GetComponent<ChampionController>().enabled = false;
+        _controlChampion.GetComponentInChildren<ChampionAnimation>().ChangeState(ChampionAnimation.AnimState.Idle);
+		_controlChampion.enabled = false;
+	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
@@ -95,6 +95,17 @@ public class BattleTeam : MonoBehaviour
 		_activeChampions.Add(champion);
 	}
 
+	public void OnBattleEnd()
+	{
+		StopAllCoroutines();
+
+		int loopCount = _pilots.Count;
+		for (int i = 0; i < loopCount; ++i)
+		{
+			_pilots[i].StopChampionLogic();
+		}
+	}
+
 	public void TestColorChange(Color color)
 	{
 		foreach (var pilot in enemyTeam._pilots)


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
          - 현재 확인하기 위한 용도로 시간 띄우는 기능은 제거 안함(확인해봐야 하기 때문에)
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 배틀 스테이지 정해진 시간동안 싸우는 시스템 구현
 - 현재 테스트용도로 시간 텍스트로 띄우는 기능 추가

# 제안 사항
 - 배틀 스테이지 데이터 테이블 구현(남은 전투 시간을 저장하며 변경 시 이벤트 호출)
 > 배틀 스테이지의 정보를 필요로 하는 객체들이 있기 때문에 따로 데이터 테이블로 구성해서 접근할 수 있도록 했다.
 - 남은 전투 시간이 0이 되면 모든 필드에 있는 전투 관련 로직 실행 중단
 > 배틀이 종료되면 필드의 챔피언들은 하던 일을 정지해야 하기 때문에

# (선택)스크린샷
 - 결과
![정해진 시간 동안 전투 적용 후 결과](https://user-images.githubusercontent.com/120010342/230708293-713bff3e-baef-4d69-b16d-a0ed64a6a9c4.gif)

 - 배틀 스테이지 데이터 테이블 코드
![배틀 스테이지 데이터 테이블 로직](https://user-images.githubusercontent.com/120010342/230708296-be398cb7-3d2d-4ec7-bbcc-416ae3667871.png)

 - 배틀 스테이지 매니저 로직
![배틀 스테이지 매니저 로직](https://user-images.githubusercontent.com/120010342/230708312-b3aae790-ddcf-4b7b-a106-cd80719cf523.png)
