### PR TITLE
feat : 챔피언 배틀 정보 바뀔 때마다 테이터 테이블 변경 및 변경될 때마다 이벤트 함수 호출

### DIFF
--- a/2DProject-TeamfightManager/Assets/Scenes/BattleTestScene.unity
+++ b/2DProject-TeamfightManager/Assets/Scenes/BattleTestScene.unity
@@ -1595,6 +1595,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 327031093}
     m_Modifications:
+    - target: {fileID: 3325744912123982047, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}
+      propertyPath: m_Name
+      value: ChampionFightInfo
+      objectReference: {fileID: 0}
     - target: {fileID: 3325744912166977433, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1682,6 +1686,14 @@ PrefabInstance:
     - target: {fileID: 3325744912166977434, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}
       propertyPath: m_Name
       value: BattleStageUIParent
+      objectReference: {fileID: 0}
+    - target: {fileID: 3325744912320539724, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}
+      propertyPath: m_Name
+      value: FightStadiumInfo
+      objectReference: {fileID: 0}
+    - target: {fileID: 3325744913222546502, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}
+      propertyPath: m_Name
+      value: FightInfoParent
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3325744912166977432, guid: 2fdd4205302f9894d8fe61db38a69000, type: 3}

--- a/2DProject-TeamfightManager/Assets/Scripts/Champion/Champion.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Champion/Champion.cs
@@ -49,8 +49,9 @@ public class Champion : MonoBehaviour, IAttackable
 	private AttackAction _curAttackAction;
 
 	// 공격 시, 피격 시 등등의 이벤트..
-	public event Action<Champion, Champion, int> OnHit;		// <맞은 놈, 때린 놈> 이렇게 인수로 보냄..
-	public event Action<Champion, Champion, int> OnHill;    // <힐 당한 놈, 힐을 한 놈> 이렇게 인수로 보냄..
+	public event Action<Champion, int> OnHit;		// <때린놈, 데미지> 순으로 보냄..
+	public event Action<Champion, int> OnHill;		// <힐 당한놈, 힐량> 순으로 보냄..
+	public event Action<Champion, int> OnAttack;	// <맞은놈, 데미지> 순으로 보냄..
 	public event Action<float> OnChangedHPRatio;
 	public event Action<float> OnChangedMana;
 	public event Action<bool> OnChangedUseUltimate;
@@ -231,7 +232,8 @@ public class Champion : MonoBehaviour, IAttackable
 			lastHitChampion = hitChampion;
 		}
 
-		OnHit?.Invoke(this, hitChampion, damage);
+		OnHit?.Invoke(hitChampion, damage);
+		hitChampion.OnAttack?.Invoke(this, damage);
 		OnChangedHPRatio?.Invoke(curHp / (float)status.hp);
 
 		if (false == isDead)

--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
@@ -6,8 +6,7 @@ public class BattleStageDataTable
 	public event Action<float> OnUpdateBattleRemainTime;
 	private float _battleRemainTime = 0f;   // 배틀 총 남은 시간..
 
-	private Dictionary<Champion, BattleStageChampionDataTable> battleStageChampDataTables = new Dictionary<Champion, BattleStageChampionDataTable>();
-	public int battleStageChampDataTableCount { get => battleStageChampDataTables.Count; }
+	private Action<int, BattleInfoData>[] OnChangedChampionBattleData;
 
 	// 배틀 시간 갱신..
 	public float updateTime
@@ -19,6 +18,11 @@ public class BattleStageDataTable
 			_battleRemainTime = MathF.Max(0f, _battleRemainTime);
 			OnUpdateBattleRemainTime?.Invoke(_battleRemainTime);
 		}
+	}
+
+	public BattleStageDataTable()
+	{
+		OnChangedChampionBattleData = new Action<int, BattleInfoData>[2];
 	}
 
 	// 배틀 시작 시 총 배틀해야하는 시간 받아서 초기화하는 부분..
@@ -33,30 +37,14 @@ public class BattleStageDataTable
 		OnUpdateBattleRemainTime = null;
 	}
 
-	public void AddPilot(Pilot pilot)
+	public void ModifyChampionBattleData(BattleTeamKind teamKind, int index, BattleInfoData data)
 	{
-		BattleStageChampionDataTable battleStagePilotDataTable = new BattleStageChampionDataTable();
-		battleStagePilotDataTable.pilot = pilot;
-		battleStagePilotDataTable.champion = pilot.battleComponent.controlChampion;
-
-		// 챔피언의 이벤트 등록..
-		battleStagePilotDataTable.champion.OnHit -= OnChampionHit;
-		battleStagePilotDataTable.champion.OnHit += OnChampionHit;
-
-		battleStagePilotDataTable.champion.OnHill -= OnChampionHill;
-		battleStagePilotDataTable.champion.OnHill += OnChampionHill;
-
-		battleStageChampDataTables.Add(battleStagePilotDataTable.champion, battleStagePilotDataTable);
+		OnChangedChampionBattleData[(int)teamKind]?.Invoke(index, data);
 	}
 
-	private void OnChampionHit(Champion sufferhampion, Champion hitChampion, int damage)
+	public void AddChampionBattleDataEvent(BattleTeamKind teamKind, Action<int, BattleInfoData> callbackFunc)
 	{
-		battleStageChampDataTables[sufferhampion].takeDamage = damage;
-		battleStageChampDataTables[hitChampion].attackDamage = damage;
-	}
-
-	private void OnChampionHill(Champion sufferhampion, Champion hillChampion, int hill)
-	{
-		battleStageChampDataTables[hillChampion].attackDamage = hill;
+		OnChangedChampionBattleData[(int)teamKind] -= callbackFunc;
+		OnChangedChampionBattleData[(int)teamKind] += callbackFunc;
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
@@ -1,7 +1,11 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Dynamic;
+using System;
 using UnityEngine;
+
+public enum BattleTeamKind
+{
+	RedTeam,
+	BlueTeam
+}
 
 /// <summary>
 /// 배틀 스테이지를 관리하는 매니저 클래스..
@@ -77,23 +81,32 @@ public class BattleStageManager : MonoBehaviour
 		blueTeam = newGameobject.AddComponent<BattleTeam>();
 
 		// 각 팀 컴포넌트에서 필요한 참조들 넘겨주기..
+		redTeam.battleTeamKind = BattleTeamKind.RedTeam;
 		redTeam.enemyTeam = blueTeam;
 		redTeam.championManager = _championManager;
 		redTeam.pilotManager = _pilotManager;
 		redTeam.battleStageManager = this;
 		redTeam.spawnArea = _redTeamSpawnArea;
 
+		blueTeam.battleTeamKind = BattleTeamKind.BlueTeam;
 		blueTeam.enemyTeam = redTeam;
 		blueTeam.championManager = _championManager;
 		blueTeam.pilotManager = _pilotManager;
 		blueTeam.battleStageManager = this;
 		blueTeam.spawnArea = _blueTeamSpawnArea;
+
+		// 각 팀 컴포넌트의 이벤트 구독..
+		redTeam.OnChangedChampionBattleInfoData -= OnChangedMyChampionBattleData;
+		redTeam.OnChangedChampionBattleInfoData += OnChangedMyChampionBattleData;
+
+		redTeam.OnChangedChampionBattleInfoData -= OnChangedMyChampionBattleData;
+		blueTeam.OnChangedChampionBattleInfoData += OnChangedMyChampionBattleData;
 	}
 
 	// 배틀 스테이지의 각 팀들의 파일럿 생성해주는 함수..
 	private void SetupPilot()
 	{
-		int pilotCount = 10;
+		int pilotCount = 4;
 
 		for (int i = 0; i < pilotCount; ++i)
 		{
@@ -133,5 +146,11 @@ public class BattleStageManager : MonoBehaviour
 
 		redTeam.OnBattleEnd();
 		blueTeam.OnBattleEnd();
+	}
+
+	private void OnChangedMyChampionBattleData(BattleTeamKind teamKind, int index, BattleInfoData data)
+	{
+		Debug.Log($"정보가 변경되었다. 팀 : {teamKind.ToString()}, 인덱스 : {index}");
+		_battleStageDataTable?.ModifyChampionBattleData(teamKind, index, data);
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Stadium/BattleTeam.cs
@@ -23,9 +23,13 @@ public class BattleTeam : MonoBehaviour
 		}
 	}
 
-    private List<PilotBattle> _pilots = new List<PilotBattle>();
+	public BattleTeamKind battleTeamKind { private get; set; }
+
+	private List<PilotBattle> _pilots = new List<PilotBattle>();
 	private List<Champion> _activeChampions = new List<Champion>();
 	private List<Champion> _allChampions = new List<Champion>();
+
+	public event Action<BattleTeamKind, int, BattleInfoData> OnChangedChampionBattleInfoData;
 
 	/// <summary>
 	/// 소속될 파일럿을 추가해주는 함수..
@@ -53,12 +57,17 @@ public class BattleTeam : MonoBehaviour
 		// 초기화..
 		pilotBattleComponent.controlChampion = champion;
 		pilotBattleComponent.myTeam = this;
+		pilotBattleComponent.battleTeamIndexKey = _pilots.Count;
 		champion.transform.position = randomSpawnPoint;
 
 		// Pilot Battle Component 를 나의 팀으로 넣기..
 		_pilots.Add(pilotBattleComponent);
 		_allChampions.Add(champion);
 		_activeChampions.Add(champion);
+
+		// 파일럿 이벤트 연결..
+		pilotBattleComponent.OnChangedBattleInfoData -= OnChangedChampionBattleData;
+		pilotBattleComponent.OnChangedBattleInfoData += OnChangedChampionBattleData;
 	}
 
 	public void OnChampionDead(Champion champion)
@@ -161,10 +170,8 @@ public class BattleTeam : MonoBehaviour
 		return enemyCount;
 	}
 
-	// 내 팀 소속 챔피언이 맞았을 때 호출되는 콜백 함수..
-	// (맞은 놈, 때린 놈) <<--- 이런 식으로 인자로 들어온다.
-	private void OnHitMyTeamChampion(Champion damagedChampion, Champion hitChampion)
+	private void OnChangedChampionBattleData(int index, BattleInfoData data)
 	{
-		
+		OnChangedChampionBattleInfoData?.Invoke(battleTeamKind, index, data);
 	}
 }


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 파일럿 배틀 스크립트에서 배틀 정보 필드로 추가
 - 배틀 정보 파일럿 배틀 스크립트에서 갱신될 때마다 이벤트 함수 호출
 - 배틀 정보를 저장하는 데이터 테이블에서 정보가 갱신될 때마다 이벤트 함수 호출

# 제안 사항
 - 파일럿 배틀 스크립트에서 배틀 정보 및 BattleTeam에서 생성된 순서대로 번호를 부여받는다.
 > BattleTeam에서 BattleStageManager에게 배틀 정보가 갱신되면 넘겨줘야 하는데 인덱스로 넘겨줄 수 있도록 하기 위해
 - BattleStageManager에서 챔피언들의 전투 정보가 바뀔 때마다 데이터 테이블에 넘겨준다.
 > BattleStageManager는 모든 파일럿 및 챔피언에 대해서 알기 때문에 여기서 편하게 넘겨줄 수 있다.

# (선택)스크린샷
 - BattleStageDataTable에 함수 구독 및 호출부분
![image](https://user-images.githubusercontent.com/120010342/230839013-5077142a-2714-4a1c-bbdd-71377ab86a2d.png)

 - BattleStageManager에서 배틀 스테이지의 챔피언들의 배틀 정보가 바뀔 때마다 호출되는 콜백 함수\
![image](https://user-images.githubusercontent.com/120010342/230839395-690be84a-0fbf-4492-8e91-59a7d94fe417.png)
