### PR TITLE
feat : 현재 체력 게이지위치부터 방어막 게이지 시작하게 구현

### DIFF
--- a/2DProject-TeamfightManager/Assets/Resources/Prefabs/UI/ChampionStatusBar.prefab
+++ b/2DProject-TeamfightManager/Assets/Resources/Prefabs/UI/ChampionStatusBar.prefab
@@ -152,6 +152,95 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2355967942716874733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1113356677717820047}
+  - component: {fileID: 6021024984399900793}
+  - component: {fileID: 500173663817509223}
+  - component: {fileID: 3540143648800495617}
+  m_Layer: 5
+  m_Name: BarrierRatioBar2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1113356677717820047
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355967942716874733}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7758424402025602591}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 98, y: 6}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &6021024984399900793
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355967942716874733}
+  m_CullTransparentMesh: 1
+--- !u!114 &500173663817509223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355967942716874733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4716981, g: 0.45167318, b: 0.45167318, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1428921a5fc8c5a4f9f90a472a44133b, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3540143648800495617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355967942716874733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4eb259b546d7ffc4b9f378ca14a6adfc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3068215290992054021
 GameObject:
   m_ObjectHideFlags: 0
@@ -565,8 +654,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offsetPosition: {x: 0.1, y: -0.45, z: 0}
-  _hpBarUI: {fileID: 4402557274887770170}
-  _barrierBarUI: {fileID: 7026198308744163424}
   _mpBarUI: {fileID: 2398961504237319816}
 --- !u!1 &7758424401030127527
 GameObject:
@@ -818,6 +905,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7758424401785770345}
+  - component: {fileID: 4987024511173601548}
   m_Layer: 5
   m_Name: HPBar
   m_TagString: Untagged
@@ -838,8 +926,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7758424402025602591}
-  - {fileID: 7758424402177399149}
-  - {fileID: 6125517113099609789}
   - {fileID: 7758424402933710787}
   m_Father: {fileID: 7758424400957108252}
   m_RootOrder: 0
@@ -849,6 +935,22 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 8}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4987024511173601548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7758424401785770346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e918b43e5cac65e4a9badf6176e46a63, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _hpBarUI: {fileID: 4402557274887770170}
+  _barrierUIBar:
+  - {fileID: 7026198308744163424}
+  - {fileID: 3540143648800495617}
 --- !u!1 &7758424402025602576
 GameObject:
   m_ObjectHideFlags: 0
@@ -860,6 +962,7 @@ GameObject:
   - component: {fileID: 7758424402025602591}
   - component: {fileID: 7758424402025602589}
   - component: {fileID: 7758424402025602590}
+  - component: {fileID: 8206032478418905847}
   m_Layer: 5
   m_Name: Background
   m_TagString: Untagged
@@ -878,7 +981,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 7758424402177399149}
+  - {fileID: 6125517113099609789}
+  - {fileID: 1113356677717820047}
   m_Father: {fileID: 7758424401785770345}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -925,6 +1031,20 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8206032478418905847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7758424402025602576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &7758424402089024701
 GameObject:
   m_ObjectHideFlags: 0
@@ -1032,14 +1152,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7758424401785770345}
-  m_RootOrder: 1
+  m_Father: {fileID: 7758424402025602591}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 50, y: -0.65912}
-  m_SizeDelta: {x: 97, y: 6.5972}
-  m_Pivot: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.0000026226044}
+  m_SizeDelta: {x: 98, y: 6}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &7758424402177399147
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1192,7 +1312,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7758424402933710787}
-  - component: {fileID: 7758424402933710786}
   - component: {fileID: 7062426314630537658}
   - component: {fileID: 6898624171080313920}
   m_Layer: 5
@@ -1215,39 +1334,13 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7758424401785770345}
-  m_RootOrder: 3
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 8}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &7758424402933710786
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7758424402933710788}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 0
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!222 &7062426314630537658
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1317,14 +1410,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7758424401785770345}
-  m_RootOrder: 2
+  m_Father: {fileID: 7758424402025602591}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 50, y: -0.65912}
-  m_SizeDelta: {x: 97, y: 6.5972}
-  m_Pivot: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.0000026226044}
+  m_SizeDelta: {x: 98, y: 6}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &3901413376420188896
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1360,7 +1453,7 @@ MonoBehaviour:
   m_FillMethod: 0
   m_FillAmount: 0
   m_FillClockwise: 1
-  m_FillOrigin: 1
+  m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
 --- !u!114 &7026198308744163424

--- a/2DProject-TeamfightManager/Assets/Scripts/Champion/Champion.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Champion/Champion.cs
@@ -228,7 +228,7 @@ public class Champion : MonoBehaviour, IAttackable
 
         if (false == s_dataTableManager.attackActionDataTable.GetActionData(this.data.ultimateActionUniqueKey).isPassive)
         {
-			if (this.data.ultimateActionUniqueKey == 23)
+			//if (this.data.ultimateActionUniqueKey == 23)
 				StartCoroutine(TestUltOn());
         }
     }

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/ChampStatusBar.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/ChampStatusBar.cs
@@ -22,9 +22,8 @@ public class ChampStatusBar : UIBase
 
 	private Camera _mainCamera;
 	private RectTransform _transform;
-
-	[SerializeField] private GaugeBarUI _hpBarUI;
-	[SerializeField] private GaugeBarUI _barrierBarUI;
+	
+	private HPBarUI _hpBarUI;
 	[SerializeField] private GaugeBarUI _mpBarUI;
 	private UltimateIconUI _ultimateIconUI;
 	private ChampBuffUI _buffUI;
@@ -39,11 +38,12 @@ public class ChampStatusBar : UIBase
 
 		_ultimateIconUI = GetComponentInChildren<UltimateIconUI>();
 		_buffUI = GetComponentInChildren<ChampBuffUI>();
+		_hpBarUI = GetComponentInChildren<HPBarUI>();
     }
 
 	private void Start()
 	{
-		_hpBarUI.gaugeBarColor = (teamKind == BattleTeamKind.RedTeam) ? redTeamHPBarColor : blueTeamHPBarColor;
+		_hpBarUI.SetHPBarColor((teamKind == BattleTeamKind.RedTeam) ? redTeamHPBarColor : blueTeamHPBarColor);
 	}
 
 	private void LateUpdate()
@@ -56,17 +56,17 @@ public class ChampStatusBar : UIBase
 
 	public void SetHPRatio(float ratio)
 	{
-		_hpBarUI.SetFillAmount(ratio);
+		_hpBarUI.SetHPBarGauge(ratio);
 	}
 
 	public void SetMPRatio(float ratio)
 	{
-		_mpBarUI.SetFillAmount(ratio);
+		_mpBarUI.fillAmount = ratio;
 	}
 
 	public void SetBarrierRatio(float ratio)
 	{
-		_barrierBarUI.SetFillAmount(ratio);
+		_hpBarUI.SetBarrierBarGauge(ratio);
 	}
 
 	public void SetUltimateActive(bool active)

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/GaugeBarUI.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/GaugeBarUI.cs
@@ -6,7 +6,21 @@ using UnityEngine.UI;
 /// </summary>
 public class GaugeBarUI : UIBase
 {
+    private float _gaugeBarFillAmount;
+    public float fillAmount
+    {
+        get => _gaugeBarFillAmount;
+        set
+        {
+            _gaugeBarFillAmount = value;
+
+            _hpRatioGaugeImage.fillAmount = _gaugeBarFillAmount;
+		}
+	}
+
     private Image _hpRatioGaugeImage;
+    public RectTransform rectTransform { get; private set; }
+
     public Color gaugeBarColor
     {
         set
@@ -18,10 +32,6 @@ public class GaugeBarUI : UIBase
 	private void Awake()
 	{
 		_hpRatioGaugeImage = GetComponent<Image>();
-	}
-
-	public void SetFillAmount(float fillAmount)
-    {
-        _hpRatioGaugeImage.fillAmount = fillAmount;
+		rectTransform = GetComponent<RectTransform>();
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/HPBarUI.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/HPBarUI.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HPBarUI : MonoBehaviour
+{
+    [SerializeField] private GaugeBarUI _hpBarUI;
+    [SerializeField] private GaugeBarUI[] _barrierUIBar;
+
+    private float _hpBarLocalStartX;
+    private float _hpBarLocalEndX;
+    private Vector3 _hpBarStartLocalPosition;
+
+	// Start is called before the first frame update
+	void Start()
+    {
+        RectTransform hpBarTransform = _hpBarUI.rectTransform;
+
+        float hpBarWidth = hpBarTransform.rect.width;
+        _hpBarStartLocalPosition = hpBarTransform.localPosition;
+		_hpBarLocalStartX = hpBarTransform.localPosition.x;
+        _hpBarLocalEndX = _hpBarLocalStartX + hpBarWidth;
+	}
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public void SetHPBarColor(Color color)
+    {
+		_hpBarUI.gaugeBarColor = color;
+	}
+
+    public void SetHPBarGauge(float fillAmount)
+    {
+        _hpBarUI.fillAmount = fillAmount;
+    }
+
+    public void SetBarrierBarGauge(float fillAmount)
+    {
+        float curHpBarGauge = _hpBarUI.fillAmount;
+
+        float curBarrierStartPosX = Mathf.Lerp(_hpBarLocalStartX, _hpBarLocalEndX, curHpBarGauge);
+
+		Vector3 localPos = _hpBarStartLocalPosition;
+		localPos.x = curBarrierStartPosX;
+		_barrierUIBar[0].rectTransform.localPosition = localPos;
+		_barrierUIBar[0].fillAmount = 1f - curHpBarGauge;
+
+		if (curHpBarGauge + fillAmount > 1f)
+        {
+            _barrierUIBar[1].gameObject.SetActive(true);
+            _barrierUIBar[1].fillAmount = Mathf.Min(1f, fillAmount + curHpBarGauge - 1f);
+		}
+        else
+        {
+			_barrierUIBar[1].gameObject.SetActive(false);
+		}
+    }
+}

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/HPBarUI.cs.meta
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/HPBarUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e918b43e5cac65e4a9badf6176e46a63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 현재 체력 게이지위치부터 방어막 게이지가 시작되도록 구현
 - 방어막 게이지가 체력바 게이지를 오버하면 게이지 처음 위치에 추가로 나오도록 구현

# 제안 사항
 - 체력바 x좌표 시작, 끝 위치를 계산해 체력 게이지가 채워져있는 양에 따라 방어막 게이지 시작 위치 계산
 > 방어막 게이지의 시작 위치를 체력 게이지 끝에서 시작하게 하기 위해 위치를 계산
 - 방어막 게이지가 체력바 Max위치에 도달하면 체력바 시작 위치에서 추가로 게이지 띄우게 구현
 > 방어막 게이지가 체력바 게이지를 오버하면 하나의 방어막 게이지를 체력바 시작위치에서부터 따로 띄워야 하기 때문에

# 스크린샷
 - 체력바 채워진 위치에서부터 방어막 게이지 나오는 영상


https://user-images.githubusercontent.com/120010342/233919437-90bc6ec6-4a4e-4584-bcfe-ac789aa13641.mp4

 - 방어막 게이지가 체력바를 오버했을 때


https://user-images.githubusercontent.com/120010342/233919508-2c37873f-544d-44a8-a8c0-9d9c084e2493.mp4


