### PR TITLE
feat : 투사체 맵 외각 벗어나면 active 끄기

### DIFF
--- a/2DProject-TeamfightManager/Assets/Scenes/ColoseumScene.unity
+++ b/2DProject-TeamfightManager/Assets/Scenes/ColoseumScene.unity
@@ -517,7 +517,7 @@ GameObject:
   - component: {fileID: 1455532887}
   - component: {fileID: 1455532886}
   m_Layer: 6
-  m_Name: StageOutsideCollider
+  m_Name: StageAreaLimitLineCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -877,6 +877,158 @@ Transform:
   m_Father: {fileID: 2135799364}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1732650018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1732650019}
+  - component: {fileID: 1732650024}
+  - component: {fileID: 1732650023}
+  - component: {fileID: 1732650022}
+  - component: {fileID: 1732650021}
+  - component: {fileID: 1732650020}
+  m_Layer: 13
+  m_Name: StageOutsideCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1732650019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2135799364}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1732650020
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.04472661, y: -6.09}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 15.997892, y: 1}
+  m_EdgeRadius: 0
+--- !u!61 &1732650021
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.04472661, y: 5.58}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 15.997892, y: 1}
+  m_EdgeRadius: 0
+--- !u!61 &1732650022
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -8, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 14}
+  m_EdgeRadius: 0
+--- !u!61 &1732650023
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 8, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 14}
+  m_EdgeRadius: 0
+--- !u!114 &1732650024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732650018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5600db7bb8e1e994e91919285be97df3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2135799363
 GameObject:
   m_ObjectHideFlags: 0
@@ -886,6 +1038,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2135799364}
+  - component: {fileID: 2135799365}
   m_Layer: 0
   m_Name: Stadium
   m_TagString: Untagged
@@ -909,6 +1062,19 @@ Transform:
   - {fileID: 1502069660}
   - {fileID: 1700224819}
   - {fileID: 1455532890}
+  - {fileID: 1732650019}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2135799365
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2135799363}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f073d83d757aba0488a8cd32ff1e7a1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/2DProject-TeamfightManager/Assets/Scripts/Stadium/StageOutside.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Stadium/StageOutside.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StageOutside : MonoBehaviour
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if( true == collision.CompareTag("SummonObject") )
+        {
+            SummonObject summonObject = collision.GetComponent<SummonObject>();
+            if (null != summonObject)
+            {
+                summonObject.Release();
+            }
+        }
+    }
+}

--- a/2DProject-TeamfightManager/Assets/Scripts/Stadium/StageOutside.cs.meta
+++ b/2DProject-TeamfightManager/Assets/Scripts/Stadium/StageOutside.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5600db7bb8e1e994e91919285be97df3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/2DProject-TeamfightManager/Assets/Scripts/SummonObject/SummonObject.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/SummonObject/SummonObject.cs
@@ -23,6 +23,8 @@ public class SummonObject : MonoBehaviour
 
 	private void Start()
 	{
+		gameObject.tag = "SummonObject";
+
 		if (null != summonObjectManager)
 		{
 			summonObjectManager.OnForcedRelease -= OnForcedRelease;
@@ -54,6 +56,12 @@ public class SummonObject : MonoBehaviour
 		if (false == gameObject.activeSelf)
 			return;
 
+		summonObjectManager.ReleaseSummonObject(this);
+	}
+
+	public void Release()
+	{
+		ReceiveReleaseEvent();
 		summonObjectManager.ReleaseSummonObject(this);
 	}
 }

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/GameResultUI.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Battle/GameResultUI.cs
@@ -41,7 +41,7 @@ public class GameResultUI : UIBase
         string blueTeamName = blueTeam.teamName;
 
         _redTeamLogoImage.sprite = s_dataTableManager.teamDataTable.GetLogoSprite(redTeamName);
-        _blueTeamLogoImage.sprite = s_dataTableManager.teamDataTable.GetLogoSprite(redTeamName);
+        _blueTeamLogoImage.sprite = s_dataTableManager.teamDataTable.GetLogoSprite(blueTeamName);
 
         _redTeamNameText.text = redTeamName;
         _blueTeamNameText.text = blueTeamName;


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 투사체 혹은 소환물 중 날아가는 오브젝트들이 맵 외각을 벗어나면 active 끄기

# 제안 사항
 - 맵 외각을 벗어나면 active를 끄고 pooling중인 오브젝트는 pooler에 넣어주도록 구현
 > pooling중인 오브젝트는 active만 끄면 재사용할 수 없기 때문에

# 스크린샷
 - 결과

https://user-images.githubusercontent.com/120010342/234968917-9e651155-b7f6-4dd6-9f8d-9ad37ca90f8a.mp4




