### PR TITLE
feat : 밴픽 AI팀 턴에는 AI가 픽하도록 수정 및 밴픽UI 누구의 턴인지 제대로 나오도록 수정

### DIFF
--- a/2DProject-TeamfightManager/Assets/Data/GameGlobalData.asset
+++ b/2DProject-TeamfightManager/Assets/Data/GameGlobalData.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07a55e2eef29155488a241fd5cafc05e, type: 3}
   m_Name: GameGlobalData
   m_EditorClassIdentifier: 
-  PilotCount: 1
+  PilotCount: 4
   battleFightTime: 10
   playerTeamName: TeamFourMan
   pilotGlobalFilePath: PilotGlobal.data
@@ -23,7 +23,7 @@ MonoBehaviour:
   attackActionImpactDataFileName: AttackActionDataFile_ImpactData.csv
   effectFileName: EffectDataFile.csv
   teamFileName: TeamDataFile.csv
-  banpickStageGlobalData: {fileID: 11400000, guid: c913512666f128b4a8585530ae168924, type: 2}
+  banpickStageGlobalData: {fileID: 11400000, guid: a0ce79ad6f2699842a9a14b016d4f589, type: 2}
   spawnObjectGolbalData: {fileID: 11400000, guid: 86c2ca5ccf2caf04d9bfd1fdf0a03f14, type: 2}
   pilotTrunkSprite: {fileID: 21300000, guid: 907a154bac407634a8ce897f7ee42708, type: 3}
   pilotHairSprite:

--- a/2DProject-TeamfightManager/Assets/Scenes/BanpickScene.unity
+++ b/2DProject-TeamfightManager/Assets/Scenes/BanpickScene.unity
@@ -2018,8 +2018,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1174386086}
-  - {fileID: 1445771335}
   - {fileID: 1266396081}
+  - {fileID: 1445771335}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3828,7 +3828,7 @@ RectTransform:
   m_Children:
   - {fileID: 205798402}
   m_Father: {fileID: 627696171}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4504,12 +4504,12 @@ RectTransform:
   - {fileID: 45110075}
   - {fileID: 1377075415}
   m_Father: {fileID: 627696171}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -1000}
-  m_SizeDelta: {x: 1920, y: 1080}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1445771336
 MonoBehaviour:

--- a/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/DataTable/BattleStageDataTable.cs
@@ -10,12 +10,14 @@ public class BattleStageDataTable
 		public BanpickStageKind stageKind;
 		public BattleTeamKind teamKind;
 		public int level;
+		public int progressStageNumber;
 
-		public void Set(BanpickStageKind stageKind, BattleTeamKind teamKind, int level)
+		public void Set(BanpickStageKind stageKind, BattleTeamKind teamKind, int level, int progressStageNumber)
 		{
 			this.stageKind = stageKind;
 			this.teamKind = teamKind;
 			this.level = level;
+			this.progressStageNumber = progressStageNumber;
 		}
 
 		public void Reset()
@@ -24,6 +26,7 @@ public class BattleStageDataTable
 			stageKind = BanpickStageKind.None;
 			teamKind = BattleTeamKind.End;
 			level = 0;
+			progressStageNumber = 0;
 		}
 	}
 		
@@ -70,17 +73,22 @@ public class BattleStageDataTable
 	}
 
 	public BanpickStageInfo curBanpickStageInfo { get; set; }
+	public BanpickStageInfo nextBanpickStageInfo { get; set; }
 	public BattleTeamFightData redTeamBattleFightData { get; private set; }
 	public BattleTeamFightData blueTeamBattleFightData { get; private set; }
 	public int maxBanpickLevel { get; set; }
 	public int totalBanChampCount { get; set; }
 	public int curBanpickLevel { get; private set; }
+	public List<string> banpickChampionList { get; private set; }
+	public bool isPauseBanpick { get; set; }
 
 	public BattleStageDataTable()
 	{
 		curBanpickStageInfo = new BanpickStageInfo();
+		nextBanpickStageInfo = new BanpickStageInfo();
 		redTeamBattleFightData = new BattleTeamFightData();
 		blueTeamBattleFightData = new BattleTeamFightData();
+		banpickChampionList = new List<string>();
 
 		curBanpickLevel = 1;
 	}
@@ -106,8 +114,11 @@ public class BattleStageDataTable
 	{
 		OnUpdateBattleRemainTime = null;
 
+		curBanpickStageInfo.Reset();
+		nextBanpickStageInfo.Reset();
+
 		banpickChampContainer.Clear();
-        curBanpickStageInfo.Reset();
+		banpickChampionList.Clear();
 
 		redTeamBattleFightData.teamName = "";
 		redTeamBattleFightData.teamTotalKill = 0;
@@ -146,6 +157,7 @@ public class BattleStageDataTable
 
 	public void UpdateBanpickData(string championName, BanpickStageKind stageKind, BattleTeamKind teamKind, int index)
 	{
+		banpickChampionList.Add(championName);
 		curBanpickStageInfo.champName = championName;
 		OnBanpickUpdate?.Invoke(championName, stageKind, teamKind, index);
 
@@ -173,7 +185,7 @@ public class BattleStageDataTable
 	
 	public void StartBanpick(BanpickStageKind stageKind, BattleTeamKind teamKind)
 	{
-		curBanpickStageInfo.Set(stageKind, teamKind, 0);
+		curBanpickStageInfo.Set(stageKind, teamKind, 0, 1);
 	}
 
 	public void StartBanpickOneStage(BanpickStageKind curStageKind)

--- a/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/Manager/BattleStageManager.cs
@@ -165,6 +165,19 @@ public class BattleStageManager : MonoBehaviour
 		}
 	}
 
+	public void ProgressBanpick(BanpickRunner banpickRunner, BattleTeamKind curTurnTeamKind)
+	{
+		switch (curTurnTeamKind)
+		{
+			case BattleTeamKind.RedTeam:
+				redTeam.ProgressMyTurnBanpick(banpickRunner);
+				break;
+			case BattleTeamKind.BlueTeam:
+				blueTeam.ProgressMyTurnBanpick(banpickRunner);
+				break;
+		}
+	}
+
 	// 팀 종류와 인덱스를 받아와 챔피언의 이름을 리턴하는 함수..
 	public string GetChampionName(BattleTeamKind teamKind, int index)
 	{

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Banpick/BanpickBlockingProcess.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Banpick/BanpickBlockingProcess.cs
@@ -48,8 +48,10 @@ public class BanpickBlockingProcess : UIBase
     {
         while(true)
         {
-            // 초기화..
-            float curAlpha = 0f;
+			// 초기화..
+			s_dataTableManager.battleStageDataTable.isPauseBanpick = true;
+
+			float curAlpha = 0f;
             float alphaAcc = _alphaHighlightTime / 1f;
 
             _curStageText.alpha = 0f;
@@ -82,11 +84,13 @@ public class BanpickBlockingProcess : UIBase
 			gameObject.SetActive(false);
             OnEndProcess?.Invoke();
 
+			s_dataTableManager.battleStageDataTable.isPauseBanpick = false;
+
 			StopCoroutine(_updateBlockingCoroutine);
 
             yield return null;
 		}
-    }
+	}
 
     public void OnEndTextMove()
     {

--- a/2DProject-TeamfightManager/Assets/Scripts/UI/Banpick/ShowCurBanpickStageUI.cs
+++ b/2DProject-TeamfightManager/Assets/Scripts/UI/Banpick/ShowCurBanpickStageUI.cs
@@ -53,7 +53,10 @@ public class ShowCurBanpickStageUI : UIBase
 
     private void UpdateBanpickData( string championName, BanpickStageKind stageKind, BattleTeamKind teamKind, int index )
     {
-        ModifyBanpickData( (teamKind == BattleTeamKind.BlueTeam) ? BattleTeamKind.RedTeam : BattleTeamKind.BlueTeam, _battleStageDataTable.curBanpickLevel + 1 );
+        teamKind = _battleStageDataTable.curBanpickStageInfo.teamKind;
+        int stage = _battleStageDataTable.curBanpickStageInfo.progressStageNumber;
+
+		ModifyBanpickData( teamKind, stage );
     }
 
     private void ModifyBanpickData(BattleTeamKind teamKind, int curPickNumber )


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
 - 밴픽 AI턴에는 AI가 픽하도록 구현
 - 밴픽 UI 현재 누구의 턴인지 제대로 나오도록 수정

# 제안 사항
 - 밴픽에서 누구의 턴인지 검사한 뒤 현재 턴인 팀이 플레이어 팀인지 AI 팀인지 검사 후 그에 맞게 진행하도록 구현
 - 밴픽 UI에서 픽했을 때 현재 턴에 대한 정보를 받아와 그에 맞게 출력하도록 수정

# 스크린샷
 - 결과


https://user-images.githubusercontent.com/120010342/235099990-0273bf06-db74-4b5d-9025-d052eac9b430.mp4



